### PR TITLE
feat: add qdrant docker stack and miner bootstrap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: edurag-qdrant
+    restart: unless-stopped
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ./data/qdrant:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s

--- a/miner/README.md
+++ b/miner/README.md
@@ -5,11 +5,33 @@ Miner는 RAG(Retrieval-Augmented Generation) 저장소를 생성하기 위한 �
 ## 요구 사항
 - [uv](https://github.com/astral-sh/uv) 0.5.0 이상
 - Python 3.11 이상
+- [Docker](https://www.docker.com/) 및 Docker Compose
 
 ## 시작하기
 ```bash
 # 저장소 루트에서 의존성 설치 후 실행
-uv run python miner/main.py
+uv run python -m miner.main --help
 ```
 
-현재는 초기화 메시지를 출력하는 간단한 스켈레톤 상태이며, 추후 RAG 파이프라인을 구성하는 명령형 도구로 확장될 예정입니다.
+## Qdrant 벡터 DB 실행하기
+Miner는 [Qdrant](https://qdrant.tech/)를 기본 벡터 데이터베이스로 사용합니다. 저장소 루트에 있는 `docker-compose.yml`을 사용하여 손쉽게 로컬 개발용 인스턴스를 실행할 수 있습니다.
+
+```bash
+# Qdrant 컨테이너 실행
+docker compose up -d qdrant
+
+# 컨테이너 종료
+docker compose down
+```
+
+## 벡터 컬렉션 초기화
+벡터 데이터베이스가 실행 중이라면 다음 명령으로 기본 컬렉션을 생성하거나 존재 여부를 확인할 수 있습니다.
+
+```bash
+uv run python -m miner.main \
+  --collection miner-documents \
+  --vector-size 1536 \
+  --distance cosine
+```
+
+환경 변수 `QDRANT_HOST`, `QDRANT_PORT`, `QDRANT_API_KEY`를 사용하여 접속 정보를 구성할 수 있으며, `MINER_COLLECTION`, `MINER_VECTOR_SIZE`, `MINER_DISTANCE` 값으로 기본 설정을 재정의할 수 있습니다.

--- a/miner/__init__.py
+++ b/miner/__init__.py
@@ -1,0 +1,5 @@
+"""Miner package exposing utilities for bootstrapping the vector database."""
+
+from .vector_db import VectorCollectionConfig, create_client, ensure_collection
+
+__all__ = ["VectorCollectionConfig", "create_client", "ensure_collection"]

--- a/miner/main.py
+++ b/miner/main.py
@@ -1,6 +1,95 @@
-def main() -> None:
-    """Entry point for the Miner CLI."""
-    print("Miner: RAG repository scaffolder initialized.")
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Literal
+
+from qdrant_client.http import models as qmodels
+
+from miner.vector_db import VectorCollectionConfig, create_client, ensure_collection
+
+DistanceLiteral = Literal["cosine", "dot", "euclid"]
+
+
+DISTANCE_MAP: dict[DistanceLiteral, qmodels.Distance] = {
+    "cosine": qmodels.Distance.COSINE,
+    "dot": qmodels.Distance.DOT,
+    "euclid": qmodels.Distance.EUCLID,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Miner: Qdrant vector database bootstrapper. "
+            "Ensures that a collection exists with the requested configuration."
+        )
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("QDRANT_HOST", "localhost"),
+        help="Host where the Qdrant service is reachable.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("QDRANT_PORT", "6333")),
+        help="HTTP port exposed by the Qdrant service.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("QDRANT_API_KEY"),
+        help="Optional API key if the Qdrant instance is secured.",
+    )
+    parser.add_argument(
+        "--collection",
+        default=os.getenv("MINER_COLLECTION", "miner-documents"),
+        help="Name of the collection to ensure.",
+    )
+    parser.add_argument(
+        "--vector-size",
+        type=int,
+        default=int(os.getenv("MINER_VECTOR_SIZE", "1536")),
+        help="Dimensionality of the vectors that will be stored.",
+    )
+    parser.add_argument(
+        "--distance",
+        choices=list(DISTANCE_MAP),
+        default=os.getenv("MINER_DISTANCE", "cosine"),
+        help="Distance function used when comparing vectors.",
+    )
+    parser.add_argument(
+        "--on-disk",
+        action="store_true",
+        help="Store vectors on disk instead of RAM for the target collection.",
+    )
+    return parser
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = build_parser()
+    parsed = parser.parse_args(args=args)
+
+    client = create_client(parsed.host, parsed.port, parsed.api_key)
+
+    config = VectorCollectionConfig(
+        name=parsed.collection,
+        vector_size=parsed.vector_size,
+        distance=DISTANCE_MAP[parsed.distance],
+        on_disk=parsed.on_disk,
+    )
+
+    created = ensure_collection(client, config)
+
+    if created:
+        print(
+            f"Collection '{config.name}' created with size {config.vector_size} "
+            f"and distance {parsed.distance}."
+        )
+    else:
+        print(
+            f"Collection '{config.name}' already exists. No action was necessary."
+        )
 
 
 if __name__ == "__main__":

--- a/miner/pyproject.toml
+++ b/miner/pyproject.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 description = "RAG repository scaffolding toolkit"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "qdrant-client>=1.9.0",
+]

--- a/miner/vector_db.py
+++ b/miner/vector_db.py
@@ -1,0 +1,54 @@
+"""Utility helpers for interacting with the Qdrant vector database."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qmodels
+
+
+@dataclass
+class VectorCollectionConfig:
+    """Configuration for a collection to be created in Qdrant."""
+
+    name: str
+    vector_size: int
+    distance: qmodels.Distance = qmodels.Distance.COSINE
+    on_disk: bool = False
+
+    def to_vector_params(self) -> qmodels.VectorParams:
+        """Convert the configuration to ``VectorParams`` understood by Qdrant."""
+
+        return qmodels.VectorParams(
+            size=self.vector_size,
+            distance=self.distance,
+            on_disk=self.on_disk,
+        )
+
+
+def create_client(host: str, port: int, api_key: Optional[str] = None) -> QdrantClient:
+    """Create a ``QdrantClient`` from the provided connection information."""
+
+    return QdrantClient(host=host, port=port, api_key=api_key)
+
+
+def ensure_collection(client: QdrantClient, config: VectorCollectionConfig) -> bool:
+    """Ensure that a collection exists, creating it if necessary.
+
+    Args:
+        client: The Qdrant client to use for operations.
+        config: Desired collection configuration.
+
+    Returns:
+        ``True`` if a collection was created, ``False`` if it already existed.
+    """
+
+    if client.collection_exists(config.name):
+        return False
+
+    client.create_collection(
+        collection_name=config.name,
+        vectors_config=config.to_vector_params(),
+    )
+    return True


### PR DESCRIPTION
## Summary
- add a docker compose definition to spin up a local Qdrant vector database
- extend the miner package with Qdrant helpers and a CLI to provision collections
- document how to run the container and bootstrap collections for development

## Testing
- python -m compileall miner

------
https://chatgpt.com/codex/tasks/task_e_68d37a05d00c832b9780ef81905a67d8