### PR TITLE
Add Tavily search mode to Miner

### DIFF
--- a/miner/README.md
+++ b/miner/README.md
@@ -13,6 +13,24 @@ Miner는 RAG(Retrieval-Augmented Generation) 저장소를 생성하기 위한 �
 uv run python -m miner.main --help
 ```
 
+### Tavily 기반 검색 모드 활용하기
+
+AI-SEARCH 프로젝트에서 사용하던 다국어 Tavily 검색 전략을 Miner에도 도입했습니다.
+`--mode search`와 `--search-query` 옵션을 사용하면 교육·학술 분야에 특화된 웹 검색을
+실행해 수집할 만한 문서를 빠르게 파악할 수 있습니다. 검색 결과는 중복 URL을 제거한
+마크다운 형식으로 출력됩니다.
+
+```bash
+export TAVILY_API_KEY=...  # Tavily API 키 필요
+
+uv run python -m miner.main \
+  --mode search \
+  --search-query "디지털 교육 정책 동향"
+```
+
+검색 모드는 Tavily API 사용량에 따라 비용이 발생할 수 있으며, `deep-translator`
+패키지가 설치되어 있다면 쿼리를 영어로 번역해 글로벌 검색도 함께 수행합니다.
+
 ## Qdrant 벡터 DB 실행하기
 Miner는 [Qdrant](https://qdrant.tech/)를 기본 벡터 데이터베이스로 사용합니다. 저장소 루트에 있는 `docker-compose.yml`을 사용하여 손쉽게 로컬 개발용 인스턴스를 실행할 수 있습니다.
 

--- a/miner/__init__.py
+++ b/miner/__init__.py
@@ -1,5 +1,13 @@
 """Miner package exposing utilities for bootstrapping the vector database."""
 
+from .search import SearchRequest, build_search_plan, run_search
 from .vector_db import VectorCollectionConfig, create_client, ensure_collection
 
-__all__ = ["VectorCollectionConfig", "create_client", "ensure_collection"]
+__all__ = [
+    "VectorCollectionConfig",
+    "create_client",
+    "ensure_collection",
+    "SearchRequest",
+    "build_search_plan",
+    "run_search",
+]

--- a/miner/main.py
+++ b/miner/main.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from qdrant_client.http import models as qmodels
 
+from miner.search import run_search
 from miner.vector_db import VectorCollectionConfig, create_client, ensure_collection
 
 DistanceLiteral = Literal["cosine", "dot", "euclid"]
@@ -63,12 +64,35 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Store vectors on disk instead of RAM for the target collection.",
     )
+    parser.add_argument(
+        "--mode",
+        choices=["collection", "search"],
+        default="collection",
+        help=(
+            "Operation mode: 'collection' ensures the Qdrant collection exists, "
+            "while 'search' executes a Tavily web search plan to find new documents."
+        ),
+    )
+    parser.add_argument(
+        "--search-query",
+        help="Query string used when running in search mode.",
+    )
     return parser
 
 
 def main(args: list[str] | None = None) -> None:
     parser = build_parser()
     parsed = parser.parse_args(args=args)
+
+    if parsed.mode == "search":
+        if not parsed.search_query:
+            parser.error("--search-query is required when --mode=search")
+        try:
+            results = run_search(parsed.search_query)
+        except ValueError as exc:
+            parser.error(str(exc))
+        print(results)
+        return
 
     client = create_client(parsed.host, parsed.port, parsed.api_key)
 

--- a/miner/pyproject.toml
+++ b/miner/pyproject.toml
@@ -6,4 +6,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "qdrant-client>=1.9.0",
+    "deep-translator>=1.11.4",
+    "tavily-python>=0.7.12",
 ]

--- a/miner/search.py
+++ b/miner/search.py
@@ -1,0 +1,159 @@
+"""Search utilities for discovering new data sources.
+
+This module adapts the multi-lingual web search strategy from the
+``ai-search`` project so that Miner can quickly discover candidate
+documents for ingestion.  The main entry point is :func:`run_search`
+which executes a small search plan using the Tavily web search API and
+returns the aggregated findings in Markdown format.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from tavily import TavilyClient
+
+try:  # Optional dependency – the module still works without translation.
+    from deep_translator import GoogleTranslator
+except Exception:  # pragma: no cover - translation is optional at runtime.
+    GoogleTranslator = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class SearchRequest:
+    """Single Tavily search request within a larger search plan."""
+
+    label: str
+    query: str
+    options: dict[str, object]
+
+
+def _translate_query(query: str) -> str | None:
+    """Translate the query into English when possible."""
+
+    if GoogleTranslator is None:
+        return None
+
+    try:
+        translated = GoogleTranslator(source="auto", target="en").translate(query)
+    except Exception:  # pragma: no cover - network failures are handled gracefully.
+        return None
+
+    if isinstance(translated, str):
+        trimmed = translated.strip()
+        return trimmed or None
+    return None
+
+
+def build_search_plan(query: str) -> List[SearchRequest]:
+    """Create a list of focused web searches for the given query."""
+
+    plan: List[SearchRequest] = []
+    plan.append(
+        SearchRequest(
+            label="KO",
+            query=query,
+            options={
+                "language": "ko",
+                "include_domains": ["moe.go.kr", "kedi.re.kr", "ac.kr", "go.kr"],
+            },
+        )
+    )
+
+    english_query = _translate_query(query) or query
+
+    plan.append(
+        SearchRequest(
+            label="EN",
+            query=english_query,
+            options={
+                "language": "en",
+                "include_domains": [
+                    "oecd.org",
+                    "unesco.org",
+                    "worldbank.org",
+                    "eric.ed.gov",
+                    "ed.gov",
+                    "brookings.edu",
+                ],
+            },
+        )
+    )
+
+    plan.append(
+        SearchRequest(
+            label="GLOBAL",
+            query=english_query,
+            options={"language": "en", "search_depth": "advanced"},
+        )
+    )
+
+    return plan
+
+
+def _resolve_client(api_key: str | None, client: "TavilyClient | None") -> "TavilyClient":
+    """Return a Tavily client instance, importing lazily when necessary."""
+
+    if client is not None:
+        return client
+    if not api_key:
+        raise ValueError("TAVILY_API_KEY environment variable is not set.")
+
+    try:  # Local import keeps the dependency optional until actually needed.
+        from tavily import TavilyClient as _TavilyClient  # type: ignore
+    except Exception as exc:  # pragma: no cover - import depends on optional dep.
+        raise RuntimeError(
+            "tavily-python package is required to run Miner search mode."
+        ) from exc
+
+    return _TavilyClient(api_key=api_key)
+
+
+def run_search(query: str, *, client: "TavilyClient | None" = None) -> str:
+    """Execute the Tavily search plan and return aggregated Markdown output."""
+
+    api_key = os.getenv("TAVILY_API_KEY")
+    client = _resolve_client(api_key, client)
+
+    sections: List[str] = []
+    seen_urls: set[str] = set()
+
+    for request in build_search_plan(query):
+        try:
+            response = client.search(query=request.query, **request.options)
+            items = response.get("results", [])
+        except Exception as exc:  # pragma: no cover - depends on external API.
+            sections.append(f"### [{request.label}] 검색 실패\n- 오류: {exc}")
+            continue
+
+        if not items:
+            sections.append(
+                f"### [{request.label}] 검색 결과 없음\n- 사용 쿼리: {request.query}"
+            )
+            continue
+
+        lines: List[str] = []
+        for item in items:
+            title = item.get("title") or "제목 없음"
+            url = item.get("url") or "URL 없음"
+            snippet = item.get("content") or item.get("snippet") or "요약 없음"
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
+            lines.append(
+                f"- **{title}**\n  - URL: {url}\n  - 요약: {snippet}"
+            )
+
+        body = "\n".join(lines) if lines else "- 신규 정보 없음"
+        sections.append(
+            f"### [{request.label}] 검색 결과\n- 사용 쿼리: {request.query}\n{body}"
+        )
+
+    return "\n\n".join(sections)
+
+
+__all__: Iterable[str] = ["SearchRequest", "build_search_plan", "run_search"]
+


### PR DESCRIPTION
## Summary
- add a Tavily-backed search module that mirrors AI-SEARCH's multilingual discovery plan for Miner
- expose the search workflow through the existing CLI alongside the collection bootstrapper and document it
- declare the additional optional dependencies needed for translation and Tavily access

## Testing
- `uv run python -m miner.main --help` *(fails: missing optional dependencies such as qdrant-client and Tavily packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37c74e5d4832b9618604cadc5db4a