### PR TITLE
Integrate Elasticsearch storage for AI search reports

### DIFF
--- a/ai-search-web/ai_search_web/elasticsearch_client.py
+++ b/ai-search-web/ai_search_web/elasticsearch_client.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from elasticsearch import Elasticsearch
+
+from ai_search_web.settings import settings
+
+
+class ElasticsearchConfigurationError(RuntimeError):
+    """Raised when the Elasticsearch connection is not configured."""
+
+
+@lru_cache(maxsize=1)
+def get_client() -> Elasticsearch:
+    host = settings.es_host
+    if not host:
+        raise ElasticsearchConfigurationError(
+            "Elasticsearch host is not configured. Set the ES_HOST environment variable."
+        )
+
+    username: Optional[str] = settings.es_username
+    password: Optional[str] = settings.es_password
+
+    if username and password:
+        return Elasticsearch(hosts=[host], basic_auth=(username, password))
+    return Elasticsearch(hosts=[host])

--- a/ai-search-web/ai_search_web/settings.py
+++ b/ai-search-web/ai_search_web/settings.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -14,23 +13,24 @@ load_dotenv()
 class Settings:
     """Configuration values for the ai-search web UI."""
 
-    reports_dir: Path
     google_api_key: Optional[str]
     openai_api_key: Optional[str]
     tavily_api_key: Optional[str]
-
-
-def _default_reports_dir() -> Path:
-    candidate = os.getenv("REPORTS_DIR") or os.path.join("..", "ai-search", "reports")
-    return Path(candidate).resolve()
+    es_host: Optional[str]
+    es_username: Optional[str]
+    es_password: Optional[str]
+    es_index: str
 
 
 def load_settings() -> Settings:
     return Settings(
-        reports_dir=_default_reports_dir(),
         google_api_key=os.getenv("GOOGLE_API_KEY") or os.getenv("GENAI_API_KEY"),
         openai_api_key=os.getenv("OPENAI_API_KEY"),
         tavily_api_key=os.getenv("TAVILY_API_KEY"),
+        es_host=os.getenv("ES_HOST"),
+        es_username=os.getenv("ES_USERNAME"),
+        es_password=os.getenv("ES_PASSWORD"),
+        es_index=os.getenv("ES_INDEX", "ai-search-reports"),
     )
 
 

--- a/ai-search-web/pyproject.toml
+++ b/ai-search-web/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.13"
 dependencies = [
     "python-dotenv>=1.1.1",
     "streamlit>=1.49.1",
+    "elasticsearch>=8.17.0",
 ]

--- a/ai-search/ai_search/config/settings.py
+++ b/ai-search/ai_search/config/settings.py
@@ -19,6 +19,10 @@ class Settings:
     tavily_api_key: Optional[str]
     model_name: str
     reports_dir: Path
+    es_host: Optional[str]
+    es_username: Optional[str]
+    es_password: Optional[str]
+    es_index: str
 
 
 def load_settings() -> Settings:
@@ -33,6 +37,10 @@ def load_settings() -> Settings:
             or "gemini-2.0-flash-thinking-exp"
         ),
         reports_dir=Path(os.getenv("REPORTS_DIR", "reports")).resolve(),
+        es_host=os.getenv("ES_HOST"),
+        es_username=os.getenv("ES_USERNAME"),
+        es_password=os.getenv("ES_PASSWORD"),
+        es_index=os.getenv("ES_INDEX", "ai-search-reports"),
     )
 
 

--- a/ai-search/ai_search/storage/elasticsearch_client.py
+++ b/ai-search/ai_search/storage/elasticsearch_client.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from elasticsearch import Elasticsearch
+
+from ai_search.config.settings import settings
+
+
+class ElasticsearchConfigurationError(RuntimeError):
+    """Raised when Elasticsearch has not been configured."""
+
+
+@lru_cache(maxsize=1)
+def get_client() -> Elasticsearch:
+    """Initialise and cache the Elasticsearch client."""
+    host = settings.es_host
+    if not host:
+        raise ElasticsearchConfigurationError(
+            "Elasticsearch host is not configured. Set the ES_HOST environment variable."
+        )
+
+    username: Optional[str] = settings.es_username
+    password: Optional[str] = settings.es_password
+
+    if username and password:
+        return Elasticsearch(hosts=[host], basic_auth=(username, password))
+    return Elasticsearch(hosts=[host])

--- a/ai-search/ai_search/storage/report_manager.py
+++ b/ai-search/ai_search/storage/report_manager.py
@@ -1,47 +1,79 @@
 from __future__ import annotations
 
-import uuid
-from pathlib import Path
+from datetime import datetime, timezone
 from typing import Optional
 
+from elasticsearch import Elasticsearch
+
 from ai_search.config.settings import settings
+from ai_search.storage.elasticsearch_client import (
+    ElasticsearchConfigurationError,
+    get_client,
+)
 
-SUPPORTED_FORMATS = {"md", "txt"}
-DEFAULT_ENCODING = "utf-8"
-
-
-def _normalise_directory(directory: Optional[str]) -> Path:
-    if directory:
-        return Path(directory).resolve()
-    return settings.reports_dir
+_INDEX_INITIALISED = False
 
 
-def save_report(question: str, content: str, directory: Optional[str] = None, report_format: str = "md") -> Optional[str]:
-    """Persist an analysis report and return the absolute path."""
-    report_format = report_format.lower()
-    if report_format not in SUPPORTED_FORMATS:
-        raise ValueError(f"Unsupported report format: {report_format}")
+def _ensure_index(client: Elasticsearch) -> None:
+    """Create the target index if it does not already exist."""
+    global _INDEX_INITIALISED
+    if _INDEX_INITIALISED:
+        return
 
-    target_dir = _normalise_directory(directory)
-    target_dir.mkdir(parents=True, exist_ok=True)
+    index_name = settings.es_index
+    try:
+        if not client.indices.exists(index=index_name):
+            client.indices.create(
+                index=index_name,
+                mappings={
+                    "properties": {
+                        "question": {"type": "text"},
+                        "content": {"type": "text"},
+                        "created_at": {"type": "date"},
+                    }
+                },
+            )
+        _INDEX_INITIALISED = True
+    except Exception as exc:  # noqa: BLE001 - surface full error for CLI visibility
+        raise RuntimeError(
+            f"Failed to ensure Elasticsearch index '{index_name}' exists: {exc}"
+        ) from exc
 
-    suffix = ".md" if report_format == "md" else ".txt"
-    file_path = target_dir / f"{uuid.uuid1()}{suffix}"
 
-    if report_format == "md":
-        file_contents = f"# 질문\n\n{question}\n\n---\n\n# 분석 리포트\n\n{content}"
-    else:
-        file_contents = (
-            "[질문]\n"
-            f"{question}\n\n"
-            "[분석 리포트]\n"
-            f"{content}"
-        )
+def save_report(
+    question: str,
+    content: str,
+    directory: Optional[str] = None,
+    report_format: str = "md",
+) -> Optional[str]:
+    """Persist an analysis report to Elasticsearch and return the document id."""
+
+    del directory, report_format  # Unused with Elasticsearch storage
 
     try:
-        file_path.write_text(file_contents, encoding=DEFAULT_ENCODING)
-        print(f"[보고서 저장 완료] {file_path}")
-        return str(file_path)
+        client = get_client()
+        _ensure_index(client)
+    except ElasticsearchConfigurationError as exc:
+        print(f"[  ] {exc}")
+        return None
     except Exception as exc:  # noqa: BLE001 - surface full error for CLI visibility
-        print(f"[보고서 저장 실패] {exc}")
+        print(f"[  ] {exc}")
+        return None
+
+    document = {
+        "question": question,
+        "content": content,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        response = client.index(index=settings.es_index, document=document)
+        document_id = response.get("_id")
+        print(
+            "[  狗] Stored report in Elasticsearch "
+            f"(index={settings.es_index}, id={document_id})"
+        )
+        return document_id
+    except Exception as exc:  # noqa: BLE001 - surface full error for CLI visibility
+        print(f"[  ] Failed to store report in Elasticsearch: {exc}")
         return None

--- a/ai-search/pyproject.toml
+++ b/ai-search/pyproject.toml
@@ -16,4 +16,5 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "scikit-learn>=1.7.2",
     "tavily-python>=0.7.12",
+    "elasticsearch>=8.17.0",
 ]


### PR DESCRIPTION
## Summary
- add Elasticsearch dependencies and configuration knobs for both the CLI and web viewer
- persist generated reports to Elasticsearch instead of the local filesystem
- update the Streamlit UI to read reports from Elasticsearch and display metadata

## Testing
- uv run --project ai-search python -m compileall ai_search *(fails: PyPI access blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d37c3097c0832b99ad7f40d33dfbf0