### PR TITLE
Add Elasticsearch docker service for local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 변경 로그 형식은 Keep a Changelog(https://keepachangelog.com/ko/1.1.0/)를 참고하며, 프로젝트는 Semantic Versioning(https://semver.org/lang/ko/)을 준수합니다.
 
+## [Unreleased]
+
+### 추가됨
+- 로컬 개발 환경에서 분석 리포트를 저장할 수 있도록 Elasticsearch용 Docker Compose 서비스를 추가했습니다.
+
 ## [0.1.0] - 2025-09-24
 
 ### 변경됨

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,34 @@ services:
       timeout: 3s
       retries: 5
       start_period: 10s
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.3
+    container_name: edurag-elasticsearch
+    restart: unless-stopped
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      xpack.security.enabled: "false"
+      cluster.routing.allocation.disk.threshold_enabled: "false"
+    ports:
+      - "9200:9200"
+    volumes:
+      - ./data/elasticsearch:/usr/share/elasticsearch/data
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:9200/_cluster/health?pretty=false | grep -q '"status":"green"'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s


### PR DESCRIPTION
## Summary
- add an Elasticsearch service to the shared docker-compose file for local report storage
- persist Elasticsearch data in a tracked volume directory alongside Qdrant
- document the new container availability in the changelog

## Testing
- docker compose config *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d37fc698d0832bb7fff0c26424eb91