### PR TITLE
Expose backend API and connect Streamlit question workflow

### DIFF
--- a/ai-search-web/ai_search_web/app.py
+++ b/ai-search-web/ai_search_web/app.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
+import requests
 import streamlit as st
 
 from ai_search_web.elasticsearch_client import (
@@ -36,6 +37,26 @@ def fetch_reports() -> List[Dict[str, str]]:
             }
         )
     return documents
+
+
+def submit_question(question: str) -> Dict[str, object]:
+    """Send the user's question to the backend analysis service."""
+
+    if not settings.api_base_url:
+        raise RuntimeError("AI Search 백엔드 URL이 설정되지 않았습니다.")
+
+    base_url = settings.api_base_url.rstrip("/")
+    try:
+        response = requests.post(
+            f"{base_url}/query",
+            json={"question": question},
+            timeout=120,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"백엔드 요청 중 오류가 발생했습니다: {exc}") from exc
+
+    return response.json()
 
 
 def process_latex(text: str) -> str:
@@ -97,7 +118,7 @@ def render_sidebar(reports: List[Dict[str, str]]) -> Dict[str, str] | None:
     return selected_report
 
 
-st.set_page_config(page_title="연구 보고서 뷰어", layout="wide")
+st.set_page_config(page_title="연구 보고서", layout="wide")
 st.markdown(
     """
     <style>
@@ -106,6 +127,73 @@ st.markdown(
     """,
     unsafe_allow_html=True,
 )
+
+if "latest_result" not in st.session_state:
+    st.session_state["latest_result"] = None
+if "refresh_reports" not in st.session_state:
+    st.session_state["refresh_reports"] = False
+
+st.title("연구 보고서 생성 및 조회")
+
+with st.form("question_form"):
+    question_input = st.text_area(
+        "연구 질문을 입력하세요",
+        placeholder="예: 생성형 AI 활용 사례의 최신 학술 동향을 알려줘",
+    )
+    submitted = st.form_submit_button("보고서 생성")
+
+if submitted:
+    cleaned = (question_input or "").strip()
+    if not cleaned:
+        st.warning("질문을 입력해 주세요.")
+    else:
+        try:
+            result = submit_question(cleaned)
+        except RuntimeError as exc:
+            st.error(str(exc))
+        else:
+            st.session_state["latest_result"] = result
+            st.session_state["refresh_reports"] = True
+            st.success("보고서를 생성했습니다. 아래에서 결과를 확인하세요.")
+
+if st.session_state.pop("refresh_reports", False):
+    fetch_reports.clear()
+
+latest_result: Optional[Dict[str, object]] = st.session_state.get("latest_result")
+
+if latest_result:
+    st.markdown("---")
+    st.subheader("최신 분석 결과")
+    st.markdown(f"**질문:** {latest_result.get('question', '')}")
+    st.markdown("**최종 답변**")
+    st.markdown(
+        process_latex(str(latest_result.get("final_answer", ""))),
+        unsafe_allow_html=True,
+    )
+
+    with st.expander("분석 계획"):
+        st.markdown(
+            process_latex(str(latest_result.get("analysis_plan", ""))),
+            unsafe_allow_html=True,
+        )
+
+    search_results = latest_result.get("search_results") or []
+    for search in search_results:
+        query = search.get("query", "")
+        with st.expander(f"검색 결과: {query}"):
+            for entry in search.get("results", []):
+                st.markdown(f"**{entry.get('tool', '도구')}**")
+                st.markdown(str(entry.get("content", "")))
+
+    step_results = latest_result.get("step_results") or []
+    if step_results:
+        with st.expander("세부 단계 분석"):
+            for step in step_results:
+                st.markdown(f"**{step.get('step', '')}**")
+                st.markdown(
+                    process_latex(str(step.get("output", ""))),
+                    unsafe_allow_html=True,
+                )
 
 try:
     reports = fetch_reports()
@@ -123,7 +211,7 @@ if selected_report:
     content = process_latex(selected_report.get("content", ""))
     created_at = format_timestamp(selected_report.get("created_at", ""))
 
-    st.markdown("<div class='title'>연구 보고서</div>", unsafe_allow_html=True)
+    st.markdown("<div class='title'>보고서 상세 보기</div>", unsafe_allow_html=True)
 
     with st.container():
         st.markdown(
@@ -142,5 +230,4 @@ if selected_report:
     with st.container():
         st.markdown(f"<div class='card'>{content}</div>", unsafe_allow_html=True)
 else:
-    st.title("연구 보고서")
-    st.info("왼쪽에서 보고서를 선택하면 상세 내용을 확인할 수 있습니다.")
+    st.info("왼쪽에서 보고서를 선택하면 저장된 내용을 확인할 수 있습니다.")

--- a/ai-search-web/ai_search_web/settings.py
+++ b/ai-search-web/ai_search_web/settings.py
@@ -20,6 +20,7 @@ class Settings:
     es_username: Optional[str]
     es_password: Optional[str]
     es_index: str
+    api_base_url: Optional[str]
 
 
 def load_settings() -> Settings:
@@ -31,6 +32,7 @@ def load_settings() -> Settings:
         es_username=os.getenv("ES_USERNAME"),
         es_password=os.getenv("ES_PASSWORD"),
         es_index=os.getenv("ES_INDEX", "ai-search-reports"),
+        api_base_url=os.getenv("AI_SEARCH_API", "http://localhost:8000"),
     )
 
 

--- a/ai-search-web/pyproject.toml
+++ b/ai-search-web/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "streamlit>=1.49.1",
     "elasticsearch>=8.17.0",
+    "requests>=2.32.3",
 ]

--- a/ai-search/ai_search/__init__.py
+++ b/ai-search/ai_search/__init__.py
@@ -1,1 +1,11 @@
-"""Core package for the ai search project."""`r`r__all__ = ["agents", "cli", "config", "core", "storage", "tools"]
+"""Core package for the ai search project."""
+
+__all__ = [
+    "agents",
+    "cli",
+    "config",
+    "core",
+    "service",
+    "storage",
+    "tools",
+]

--- a/ai-search/ai_search/agents/builder.py
+++ b/ai-search/ai_search/agents/builder.py
@@ -51,7 +51,7 @@ def build_agent(tools: Sequence):
         ("system", ANALYST_PROMPT),
         (
             "system",
-            "?�음?� ?�번 분석???�해 ?�전???�의??'분석 계획 초안'?�니?? �??�계??취�?�?충실??반영???�답?�세??\n{analysis_plan}",
+            "아래의 '분석 계획 초안'을 충실히 반영해 답변해 주세요.\n{analysis_plan}",
         ),
         MessagesPlaceholder(variable_name="chat_history"),
         ("user", "{input}"),

--- a/ai-search/ai_search/core/analysis_engine.py
+++ b/ai-search/ai_search/core/analysis_engine.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+from google.api_core import exceptions as google_exceptions
+from langchain.agents import AgentExecutor
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+from ai_search.agents.builder import build_agent
+from ai_search.core.plan_parser import extract_plan_steps, extract_search_queries
+from ai_search.storage.report_manager import save_report
+from ai_search.tools import DEFAULT_TOOLCHAIN, SEARCH_TOOL_PAIRS
+
+
+class AnalysisError(RuntimeError):
+    """Raised when an analysis request cannot be completed."""
+
+
+@dataclass
+class ToolSearchResult:
+    """Container for a single tool's search output."""
+
+    tool: str
+    content: str
+
+
+@dataclass
+class SearchResult:
+    """Represents aggregated search results for a single query."""
+
+    query: str
+    results: List[ToolSearchResult] = field(default_factory=list)
+
+
+@dataclass
+class StepResult:
+    """Stores the outcome of an individual analysis step."""
+
+    step: str
+    prompt: str
+    output: str
+
+
+@dataclass
+class AnalysisResult:
+    """High level container returned after executing an analysis."""
+
+    question: str
+    analysis_plan: str
+    search_results: List[SearchResult]
+    step_results: List[StepResult]
+    final_answer: str
+    report_id: Optional[str]
+    chat_history: List[BaseMessage]
+
+    def to_dict(self) -> dict:
+        """Convert the result into a JSON-serialisable dictionary."""
+
+        return {
+            "question": self.question,
+            "analysis_plan": self.analysis_plan,
+            "search_results": [
+                {
+                    "query": search.query,
+                    "results": [
+                        {"tool": result.tool, "content": result.content}
+                        for result in search.results
+                    ],
+                }
+                for search in self.search_results
+            ],
+            "step_results": [
+                {
+                    "step": step.step,
+                    "prompt": step.prompt,
+                    "output": step.output,
+                }
+                for step in self.step_results
+            ],
+            "final_answer": self.final_answer,
+            "report_id": self.report_id,
+        }
+
+
+def _initialise_agent(toolchain: Sequence) -> tuple:
+    """Create the planner chain and the agent executor."""
+
+    planner, agent = build_agent(toolchain)
+    executor = AgentExecutor(
+        agent=agent,
+        tools=list(toolchain),
+        verbose=True,
+        handle_parsing_errors=True,
+    )
+    return planner, executor
+
+
+def _invoke_with_backoff(
+    func,
+    *args,
+    attempt_label: str = "작업",
+    max_attempts: int = 5,
+    initial_delay: int = 2,
+    **kwargs,
+):
+    """Retry Gemini calls on transient overload errors with exponential backoff."""
+
+    delay = initial_delay
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return func(*args, **kwargs)
+        except (
+            google_exceptions.ResourceExhausted,
+            google_exceptions.ServiceUnavailable,
+        ) as exc:
+            if attempt == max_attempts:
+                raise AnalysisError(
+                    f"{attempt_label} 수행 중 서비스 과부하가 지속되어 요청을 마칠 수 없습니다."
+                ) from exc
+            time.sleep(delay)
+            delay = min(delay * 2, 30)
+        except google_exceptions.GoogleAPIError as exc:
+            message = getattr(exc, "message", str(exc))
+            raise AnalysisError(f"Gemini API 호출 중 오류가 발생했습니다: {message}") from exc
+    raise AnalysisError(f"{attempt_label} 수행에 반복적으로 실패했습니다.")
+
+
+class AnalysisEngine:
+    """Coordinator that orchestrates planning, search and reporting."""
+
+    def __init__(self, toolchain: Sequence | None = None):
+        self._toolchain = list(toolchain or DEFAULT_TOOLCHAIN)
+        self._planner, self._agent_executor = _initialise_agent(self._toolchain)
+        self._chat_history: List[BaseMessage] = []
+
+    @property
+    def chat_history(self) -> List[BaseMessage]:
+        """Return the accumulated chat history."""
+
+        return list(self._chat_history)
+
+    def reset(self) -> None:
+        """Clear the internal chat history."""
+
+        self._chat_history.clear()
+
+    def run(
+        self,
+        question: str,
+        *,
+        report_format: str = "md",
+        persist_report: bool = True,
+    ) -> AnalysisResult:
+        """Execute the full analysis workflow for the supplied question."""
+
+        cleaned_question = question.strip()
+        if not cleaned_question:
+            raise ValueError("질문을 입력해 주세요.")
+
+        analysis_plan = _invoke_with_backoff(
+            self._planner.invoke,
+            {
+                "input": cleaned_question,
+                "chat_history": self._chat_history,
+            },
+            attempt_label="분석 계획",
+        )
+
+        plan_steps = extract_plan_steps(analysis_plan)
+        search_queries = extract_search_queries(analysis_plan)
+
+        search_results: List[SearchResult] = []
+        search_sections: List[str] = []
+
+        if search_queries:
+            for query in search_queries:
+                tool_outputs: List[ToolSearchResult] = []
+                section_lines: List[str] = []
+                for label, tool in SEARCH_TOOL_PAIRS:
+                    try:
+                        references = tool.invoke({"query": query})
+                    except Exception as exc:  # noqa: BLE001 - surface tool failure directly
+                        references = f"검색 실패: {exc}"
+                    tool_outputs.append(ToolSearchResult(tool=label, content=references))
+                    section_lines.append(f"#### {label}\n{references}")
+
+                search_results.append(SearchResult(query=query, results=tool_outputs))
+                search_sections.append(
+                    f"### 검색: {query}\n\n" + "\n\n".join(section_lines)
+                )
+
+        if search_sections:
+            self._chat_history.append(
+                AIMessage(content="[참고 검색]\n" + "\n\n".join(search_sections))
+            )
+
+        step_results: List[StepResult] = []
+        for step in plan_steps:
+            step_prompt = (
+                "[세부 분석 요청]\n"
+                f"{step}\n\n"
+                "위 지침을 토대로 상세한 분석 결과를 bullet 형식으로 정리해 주세요. "
+                "필요하다면 Part 1~IX 구획, 표, 코드 등을 적극적으로 활용하세요."
+            )
+
+            step_result = _invoke_with_backoff(
+                self._agent_executor.invoke,
+                {
+                    "input": step_prompt,
+                    "chat_history": self._chat_history,
+                    "analysis_plan": analysis_plan,
+                },
+                attempt_label=f"세부 분석 ({step})",
+            )
+
+            step_output = step_result["output"]
+            self._chat_history.append(HumanMessage(content=step_prompt))
+            self._chat_history.append(AIMessage(content=step_output))
+            step_results.append(StepResult(step=step, prompt=step_prompt, output=step_output))
+
+        final_result = _invoke_with_backoff(
+            self._agent_executor.invoke,
+            {
+                "input": cleaned_question,
+                "chat_history": self._chat_history,
+                "analysis_plan": analysis_plan,
+            },
+            attempt_label="최종 보고서",
+        )
+
+        final_answer = final_result["output"]
+        self._chat_history.append(HumanMessage(content=cleaned_question))
+        self._chat_history.append(AIMessage(content=final_answer))
+
+        report_id = None
+        if persist_report:
+            report_id = save_report(
+                cleaned_question,
+                final_answer,
+                report_format=report_format,
+            )
+
+        return AnalysisResult(
+            question=cleaned_question,
+            analysis_plan=analysis_plan,
+            search_results=search_results,
+            step_results=step_results,
+            final_answer=final_answer,
+            report_id=report_id,
+            chat_history=self.chat_history,
+        )
+
+
+__all__ = [
+    "AnalysisEngine",
+    "AnalysisError",
+    "AnalysisResult",
+    "SearchResult",
+    "StepResult",
+    "ToolSearchResult",
+]
+

--- a/ai-search/ai_search/service/__init__.py
+++ b/ai-search/ai_search/service/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for exposing the analysis engine via web APIs."""
+
+from .api import app
+
+__all__ = ["app"]

--- a/ai-search/ai_search/service/api.py
+++ b/ai-search/ai_search/service/api.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from ai_search.core.analysis_engine import AnalysisEngine, AnalysisError
+
+
+class QuestionRequest(BaseModel):
+    """Incoming payload for analysis requests."""
+
+    question: str = Field(..., description="사용자가 던진 연구 질문")
+
+
+class ToolResultModel(BaseModel):
+    tool: str
+    content: str
+
+
+class SearchResultModel(BaseModel):
+    query: str
+    results: list[ToolResultModel]
+
+
+class StepResultModel(BaseModel):
+    step: str
+    prompt: str
+    output: str
+
+
+class AnalysisResponse(BaseModel):
+    """Structured response returned to the caller."""
+
+    question: str
+    analysis_plan: str
+    search_results: list[SearchResultModel]
+    step_results: list[StepResultModel]
+    final_answer: str
+    report_id: str | None = None
+
+
+app = FastAPI(title="AI Search Backend", version="1.0.0")
+
+
+@app.get("/health", summary="서비스 상태 확인")
+def health_check() -> dict[str, str]:
+    """Simple health endpoint used for readiness checks."""
+
+    return {"status": "ok"}
+
+
+@app.post("/query", response_model=AnalysisResponse, summary="질문 분석")
+def run_query(payload: QuestionRequest) -> AnalysisResponse:
+    """Execute the analysis pipeline for the supplied question."""
+
+    engine = AnalysisEngine()
+
+    try:
+        result = engine.run(payload.question)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except AnalysisError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - expose unexpected server errors
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return AnalysisResponse(**result.to_dict())
+
+
+__all__ = ["app"]
+

--- a/ai-search/pyproject.toml
+++ b/ai-search/pyproject.toml
@@ -17,4 +17,8 @@ dependencies = [
     "scikit-learn>=1.7.2",
     "tavily-python>=0.7.12",
     "elasticsearch>=8.17.0",
+    "fastapi>=0.115.6",
+    "uvicorn>=0.34.0",
+    "pydantic>=2.10.5",
+    "requests>=2.32.3",
 ]


### PR DESCRIPTION
## Summary
- add an `AnalysisEngine` orchestration layer with structured results and expose it through a FastAPI service
- refactor the CLI to use the shared engine and clean up the Gemini prompt handling
- extend the Streamlit UI to submit questions to the backend, show latest answers, and wire up the new API/config dependencies

## Testing
- python -m compileall ai_search
- python -m compileall ai_search_web

------
https://chatgpt.com/codex/tasks/task_e_68d37fafc5c0832b8aa9c5cb4edce0b9