### PR TITLE
Handle engine init failures gracefully

### DIFF
--- a/ai-search/ai_search/cli/app.py
+++ b/ai-search/ai_search/cli/app.py
@@ -28,7 +28,14 @@ def run_cli(argv: list[str] | None = None) -> None:
         set_verbose(True)
         print("[안내] LangChain debug 모드가 활성화되었습니다.")
 
-    engine = AnalysisEngine()
+    try:
+        engine = AnalysisEngine()
+    except (ValueError, AnalysisError) as exc:
+        print(f"[오류] 분석 엔진을 초기화하지 못했습니다: {exc}")
+        return
+    except Exception as exc:  # noqa: BLE001 - expose unexpected failures gracefully
+        print(f"[오류] 예기치 못한 초기화 오류가 발생했습니다: {exc}")
+        return
 
     print("안녕하세요! AI 논문 분석 CLI입니다. 'exit' 을 입력하면 종료합니다.")
 

--- a/ai-search/ai_search/service/api.py
+++ b/ai-search/ai_search/service/api.py
@@ -53,7 +53,14 @@ def health_check() -> dict[str, str]:
 def run_query(payload: QuestionRequest) -> AnalysisResponse:
     """Execute the analysis pipeline for the supplied question."""
 
-    engine = AnalysisEngine()
+    try:
+        engine = AnalysisEngine()
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except AnalysisError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - expose unexpected server errors
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     try:
         result = engine.run(payload.question)

--- a/ai-search/tests/test_api.py
+++ b/ai-search/tests/test_api.py
@@ -1,0 +1,117 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _ensure_fastapi_stubs(monkeypatch):
+    if "fastapi" not in sys.modules:
+        fastapi_module = types.ModuleType("fastapi")
+
+        class HTTPException(Exception):
+            def __init__(self, status_code: int, detail: str):
+                super().__init__(detail)
+                self.status_code = status_code
+                self.detail = detail
+
+        class FastAPI:
+            def __init__(self, *args, **kwargs):
+                self.routes = {}
+
+            def get(self, path: str, **kwargs):
+                def decorator(func):
+                    self.routes[("GET", path)] = func
+                    return func
+
+                return decorator
+
+            def post(self, path: str, **kwargs):
+                def decorator(func):
+                    self.routes[("POST", path)] = func
+                    return func
+
+                return decorator
+
+        fastapi_module.FastAPI = FastAPI
+        fastapi_module.HTTPException = HTTPException
+        monkeypatch.setitem(sys.modules, "fastapi", fastapi_module)
+
+    if "pydantic" not in sys.modules:
+        pydantic_module = types.ModuleType("pydantic")
+
+        class BaseModel:
+            def __init__(self, **data):
+                for key, value in data.items():
+                    setattr(self, key, value)
+
+        def Field(default=..., **kwargs):
+            return default
+
+        pydantic_module.BaseModel = BaseModel
+        pydantic_module.Field = Field
+        monkeypatch.setitem(sys.modules, "pydantic", pydantic_module)
+
+
+def _install_engine_stub(monkeypatch, *, init_exception=None, run_exception=None, run_payload=None):
+    package_root = Path(__file__).resolve().parents[1]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+
+    _ensure_fastapi_stubs(monkeypatch)
+
+    module = types.ModuleType("ai_search.core.analysis_engine")
+
+    class StubAnalysisError(RuntimeError):
+        """Stub error used by the fake analysis engine."""
+
+    class StubAnalysisResult:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self):
+            return dict(self._payload)
+
+    class StubEngine:
+        def __init__(self):
+            if init_exception is not None:
+                raise init_exception
+
+        def run(self, question):
+            if run_exception is not None:
+                raise run_exception
+            payload = run_payload or {
+                "question": question,
+                "analysis_plan": "",
+                "search_results": [],
+                "step_results": [],
+                "final_answer": "",
+            }
+            return StubAnalysisResult(payload)
+
+    module.AnalysisEngine = StubEngine
+    module.AnalysisError = StubAnalysisError
+    module.AnalysisResult = StubAnalysisResult
+    module.SearchResult = object
+    module.StepResult = object
+    module.ToolSearchResult = object
+
+    monkeypatch.setitem(sys.modules, "ai_search.core.analysis_engine", module)
+
+    if "ai_search.service.api" in sys.modules:
+        importlib.reload(sys.modules["ai_search.service.api"])
+    else:
+        importlib.import_module("ai_search.service.api")
+
+    return sys.modules["ai_search.service.api"]
+
+
+def test_run_query_returns_500_when_engine_initialisation_fails(monkeypatch):
+    api_module = _install_engine_stub(monkeypatch, init_exception=ValueError("missing key"))
+
+    with pytest.raises(api_module.HTTPException) as exc_info:
+        api_module.run_query(api_module.QuestionRequest(question="테스트"))
+
+    assert exc_info.value.status_code == 500
+    assert "missing key" in str(exc_info.value.detail)

--- a/ai-search/tests/test_cli.py
+++ b/ai-search/tests/test_cli.py
@@ -1,0 +1,80 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _install_engine_stub(monkeypatch, *, init_exception=None, run_result=None, run_exception=None):
+    package_root = Path(__file__).resolve().parents[1]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+
+    if "langchain" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "langchain", types.ModuleType("langchain"))
+
+    if "langchain.globals" not in sys.modules:
+        globals_module = types.ModuleType("langchain.globals")
+
+        def _noop(_value=None):
+            return None
+
+        globals_module.set_debug = _noop
+        globals_module.set_verbose = _noop
+        monkeypatch.setitem(sys.modules, "langchain.globals", globals_module)
+
+    if "dotenv" not in sys.modules:
+        dotenv_module = types.ModuleType("dotenv")
+
+        def _load_dotenv(*_args, **_kwargs):
+            return None
+
+        dotenv_module.load_dotenv = _load_dotenv
+        monkeypatch.setitem(sys.modules, "dotenv", dotenv_module)
+
+    module = types.ModuleType("ai_search.core.analysis_engine")
+
+    class StubAnalysisError(RuntimeError):
+        """Stub AnalysisError used for testing."""
+
+    class StubAnalysisResult:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self):
+            return dict(self._payload)
+
+    class StubEngine:
+        def __init__(self):
+            if init_exception is not None:
+                raise init_exception
+
+        def run(self, question):
+            if run_exception is not None:
+                raise run_exception
+            return run_result or StubAnalysisResult({})
+
+    module.AnalysisEngine = StubEngine
+    module.AnalysisError = StubAnalysisError
+    module.AnalysisResult = StubAnalysisResult
+    module.SearchResult = object
+    module.StepResult = object
+    module.ToolSearchResult = object
+
+    monkeypatch.setitem(sys.modules, "ai_search.core.analysis_engine", module)
+
+    if "ai_search.cli.app" in sys.modules:
+        importlib.reload(sys.modules["ai_search.cli.app"])
+    else:
+        importlib.import_module("ai_search.cli.app")
+
+    return sys.modules["ai_search.cli.app"]
+
+
+def test_run_cli_handles_initialisation_error(monkeypatch, capsys):
+    cli_app = _install_engine_stub(monkeypatch, init_exception=ValueError("missing key"))
+
+    cli_app.run_cli([])
+
+    output = capsys.readouterr().out
+    assert "초기화" in output
+    assert "missing key" in output


### PR DESCRIPTION
## Summary
- prevent the CLI from crashing when the analysis engine cannot be initialised by reporting a clear error message instead
- guard the FastAPI service against engine initialisation failures so misconfiguration returns HTTP 500/503 responses instead of crashing
- add regression tests that stub external dependencies to ensure both the CLI and API handle missing configuration gracefully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38b972f8c832b91c4573b8ea23dbe