### PR TITLE
feat: add qdrant rag search integration

### DIFF
--- a/ai-search/ai_search/config/settings.py
+++ b/ai-search/ai_search/config/settings.py
@@ -23,6 +23,27 @@ class Settings:
     es_username: Optional[str]
     es_password: Optional[str]
     es_index: str
+    qdrant_host: str
+    qdrant_port: int
+    qdrant_api_key: Optional[str]
+    qdrant_collection: str
+    qdrant_top_k: int
+    qdrant_score_threshold: Optional[float]
+    embedding_model: str
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    return int(raw)
+
+
+def _float_env(name: str) -> Optional[float]:
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return None
+    return float(raw)
 
 
 def load_settings() -> Settings:
@@ -41,6 +62,13 @@ def load_settings() -> Settings:
         es_username=os.getenv("ES_USERNAME"),
         es_password=os.getenv("ES_PASSWORD"),
         es_index=os.getenv("ES_INDEX", "ai-search-reports"),
+        qdrant_host=os.getenv("QDRANT_HOST", "localhost"),
+        qdrant_port=_int_env("QDRANT_PORT", 6333),
+        qdrant_api_key=os.getenv("QDRANT_API_KEY"),
+        qdrant_collection=os.getenv("QDRANT_COLLECTION", "miner-documents"),
+        qdrant_top_k=_int_env("QDRANT_TOP_K", 5),
+        qdrant_score_threshold=_float_env("QDRANT_SCORE_THRESHOLD"),
+        embedding_model=os.getenv("EMBEDDING_MODEL", "text-embedding-3-large"),
     )
 
 

--- a/ai-search/ai_search/tools/__init__.py
+++ b/ai-search/ai_search/tools/__init__.py
@@ -6,12 +6,14 @@ from .tavily_tool import tavily_web_search
 from .semantic_scholar import semantic_scholar_search
 from .crossref_tool import crossref_search
 from .openalex_tool import openalex_search
+from .qdrant_rag import qdrant_rag_search
 
 DEFAULT_TOOLCHAIN: Sequence = (
     tavily_web_search,
     semantic_scholar_search,
     crossref_search,
     openalex_search,
+    qdrant_rag_search,
 )
 
 SEARCH_TOOL_PAIRS = (
@@ -19,6 +21,7 @@ SEARCH_TOOL_PAIRS = (
     ("Semantic Scholar", semantic_scholar_search),
     ("CrossRef", crossref_search),
     ("OpenAlex", openalex_search),
+    ("Qdrant RAG", qdrant_rag_search),
 )
 
 __all__ = [
@@ -28,4 +31,5 @@ __all__ = [
     "semantic_scholar_search",
     "crossref_search",
     "openalex_search",
+    "qdrant_rag_search",
 ]

--- a/ai-search/ai_search/tools/qdrant_rag.py
+++ b/ai-search/ai_search/tools/qdrant_rag.py
@@ -1,0 +1,151 @@
+"""Qdrant-backed retrieval tool used for RAG style lookups."""
+from __future__ import annotations
+
+from functools import lru_cache
+from textwrap import shorten
+from typing import Any, Iterable
+
+from langchain_core.tools import tool
+from openai import OpenAI
+from qdrant_client import QdrantClient
+
+from ai_search.config.settings import settings
+
+
+class QdrantToolError(RuntimeError):
+    """Raised when the Qdrant retrieval tool cannot be initialised."""
+
+
+def _normalise_snippet(text: str, *, width: int = 360) -> str:
+    cleaned = " ".join(text.split())
+    return shorten(cleaned, width=width, placeholder="…")
+
+
+def _pick_first(payload: dict[str, Any], keys: Iterable[str]) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+@lru_cache(maxsize=1)
+def _qdrant_client() -> QdrantClient:
+    if not settings.qdrant_host:
+        raise QdrantToolError("Qdrant 호스트 정보가 설정되지 않았습니다.")
+    return QdrantClient(
+        host=settings.qdrant_host,
+        port=settings.qdrant_port,
+        api_key=settings.qdrant_api_key,
+    )
+
+
+@lru_cache(maxsize=1)
+def _embedding_client() -> OpenAI:
+    if not settings.openai_api_key:
+        raise QdrantToolError("OPENAI_API_KEY 환경 변수를 설정해 주세요.")
+    return OpenAI(api_key=settings.openai_api_key)
+
+
+def _embed_query(query: str) -> list[float]:
+    client = _embedding_client()
+    response = client.embeddings.create(
+        model=settings.embedding_model,
+        input=[query],
+    )
+    if not response.data:
+        raise QdrantToolError("임베딩 생성에 실패했습니다.")
+    return list(response.data[0].embedding)
+
+
+def _format_result(payload: dict[str, Any], score: float | None, index: int) -> str:
+    title = _pick_first(
+        payload,
+        [
+            "title",
+            "document_title",
+            "headline",
+            "source_title",
+        ],
+    ) or f"문서 {index}"
+
+    url = _pick_first(payload, ["url", "source", "link", "source_url"])
+
+    body = _pick_first(
+        payload,
+        [
+            "content",
+            "text",
+            "chunk",
+            "body",
+            "summary",
+        ],
+    )
+    snippet = _normalise_snippet(body) if body else "본문 미제공"
+
+    meta_lines = []
+    if score is not None:
+        meta_lines.append(f"유사도 점수: {score:.3f}")
+    if url:
+        meta_lines.append(f"출처: {url}")
+
+    meta_section = "\n".join(f"- {line}" for line in meta_lines) if meta_lines else "- 추가 메타데이터 없음"
+
+    return (
+        f"#### {index}. {title}\n"
+        f"{meta_section}\n"
+        f"- 내용 발췌: {snippet}"
+    )
+
+
+@tool
+def qdrant_rag_search(query: str) -> str:
+    """Qdrant에 저장된 문서 벡터를 검색해 상위 문서를 요약합니다."""
+
+    cleaned_query = query.strip()
+    if not cleaned_query:
+        raise ValueError("검색어를 입력해 주세요.")
+
+    try:
+        vector = _embed_query(cleaned_query)
+    except Exception as exc:  # noqa: BLE001 - expose embedding failure
+        raise QdrantToolError(f"임베딩 생성 실패: {exc}") from exc
+
+    client = _qdrant_client()
+
+    search_kwargs: dict[str, Any] = {
+        "collection_name": settings.qdrant_collection,
+        "query_vector": vector,
+        "limit": max(settings.qdrant_top_k, 1),
+        "with_payload": True,
+    }
+    if settings.qdrant_score_threshold is not None:
+        search_kwargs["score_threshold"] = settings.qdrant_score_threshold
+
+    try:
+        hits = client.search(**search_kwargs)
+    except Exception as exc:  # noqa: BLE001 - surface search failure
+        raise QdrantToolError(f"Qdrant 검색 실패: {exc}") from exc
+
+    if not hits:
+        return (
+            "### Qdrant RAG 검색 결과\n"
+            "- 상위 문서를 찾지 못했습니다. 쿼리나 컬렉션 구성을 확인해 주세요."
+        )
+
+    sections = [
+        "### Qdrant RAG 검색 결과",
+        f"- 사용 컬렉션: {settings.qdrant_collection}",
+        f"- 검색 쿼리: {cleaned_query}",
+    ]
+
+    for index, point in enumerate(hits, start=1):
+        payload = dict(point.payload or {})
+        section = _format_result(payload, getattr(point, "score", None), index)
+        sections.append(section)
+
+    return "\n\n".join(sections)
+
+
+__all__ = ["qdrant_rag_search"]
+

--- a/ai-search/pyproject.toml
+++ b/ai-search/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "scikit-learn>=1.7.2",
     "tavily-python>=0.7.12",
     "elasticsearch>=8.17.0",
+    "qdrant-client>=1.11.1",
     "fastapi>=0.115.6",
     "uvicorn>=0.34.0",
     "pydantic>=2.10.5",

--- a/ai-search/uv.lock
+++ b/ai-search/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langchain-tavily" },
     { name = "openai" },
+    { name = "qdrant-client" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -37,6 +38,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.3.33" },
     { name = "langchain-tavily", specifier = ">=0.2.11" },
     { name = "openai", specifier = ">=1.107.3" },
+    { name = "qdrant-client", specifier = ">=1.11.1" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.3" },
@@ -1025,6 +1027,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1112,6 +1126,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1147,6 +1180,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/8b/76c7d325e11d97cb8eb5e261c3759e9ed6664735afbf32fdded5b580690c/qdrant_client-1.15.1.tar.gz", hash = "sha256:631f1f3caebfad0fd0c1fba98f41be81d9962b7bf3ca653bed3b727c0e0cbe0e", size = 295297, upload-time = "2025-07-31T19:35:19.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/33/d8df6a2b214ffbe4138db9a1efe3248f67dc3c671f82308bea1582ecbbb7/qdrant_client-1.15.1-py3-none-any.whl", hash = "sha256:2b975099b378382f6ca1cfb43f0d59e541be6e16a5892f282a4b8de7eff5cb63", size = 337331, upload-time = "2025-07-31T19:35:17.539Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Qdrant connection settings and defaults for vector search
- register a new qdrant_rag_search tool that retrieves and formats top RAG hits
- include qdrant-client dependency for packaging

## Testing
- `uv run pytest` *(fails: network access blocked while downloading qdrant-client)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a88d25c832b9400f0eef94865d5