### PR TITLE
Stop crawling YouTube search results in Miner

### DIFF
--- a/miner/README.md
+++ b/miner/README.md
@@ -31,6 +31,9 @@ uv run python -m miner.main \
 검색 모드는 Tavily API 사용량에 따라 비용이 발생할 수 있으며, `deep-translator`
 패키지가 설치되어 있다면 쿼리를 영어로 번역해 글로벌 검색도 함께 수행합니다.
 
+> 참고: 저작권 이슈를 피하기 위해 Tavily 검색 결과 중 `youtube.com`, `youtu.be` 등 유튜브
+> 도메인은 자동 크롤링 대상에서 제외됩니다.
+
 ## Qdrant 벡터 DB 실행하기
 Miner는 [Qdrant](https://qdrant.tech/)를 기본 벡터 데이터베이스로 사용합니다. 저장소 루트에 있는 `docker-compose.yml`을 사용하여 손쉽게 로컬 개발용 인스턴스를 실행할 수 있습니다.
 

--- a/miner/search.py
+++ b/miner/search.py
@@ -14,6 +14,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable, List, Sequence, Tuple, TYPE_CHECKING
+from urllib.parse import urlparse
 
 from gemini import generate_related_queries as gemini_generate
 
@@ -60,6 +61,30 @@ class SearchChunk:
 
     def doc_id(self) -> str:
         return f"{self.url}#chunk-{self.chunk_index}"
+
+
+_BLOCKED_CRAWL_DOMAINS: tuple[str, ...] = (
+    "youtube.com",
+    "youtu.be",
+    "youtube-nocookie.com",
+)
+
+
+def _is_crawlable_url(url: str) -> bool:
+    """Return True when the URL should be crawled for content extraction."""
+
+    try:
+        host = urlparse(url).netloc.lower()
+    except Exception:  # pragma: no cover - defensive, depends on stdlib internals.
+        return False
+
+    if not host:
+        return False
+
+    return not any(
+        host == blocked or host.endswith("." + blocked)
+        for blocked in _BLOCKED_CRAWL_DOMAINS
+    )
 
 
 @dataclass(slots=True)
@@ -497,7 +522,11 @@ def run_search(
         sections.append(section)
         context_samples.extend(contexts)
         for hit in hits:
-            if hit.url == "URL 없음" or hit.url in url_metadata:
+            if (
+                hit.url == "URL 없음"
+                or hit.url in url_metadata
+                or not _is_crawlable_url(hit.url)
+            ):
                 continue
             url_metadata[hit.url] = {
                 "query": hit.query,
@@ -507,6 +536,8 @@ def run_search(
         for url in new_urls:
             if len(urls_for_crawl) >= crawl_limit:
                 break
+            if not _is_crawlable_url(url):
+                continue
             if url not in urls_for_crawl:
                 urls_for_crawl.append(url)
 
@@ -545,7 +576,11 @@ def run_search(
             sections.append(section)
             context_samples.extend(contexts)
             for hit in hits:
-                if hit.url == "URL 없음" or hit.url in url_metadata:
+                if (
+                    hit.url == "URL 없음"
+                    or hit.url in url_metadata
+                    or not _is_crawlable_url(hit.url)
+                ):
                     continue
                 url_metadata[hit.url] = {
                     "query": hit.query,
@@ -555,6 +590,8 @@ def run_search(
             for url in new_urls:
                 if len(urls_for_crawl) >= crawl_limit:
                     break
+                if not _is_crawlable_url(url):
+                    continue
                 if url not in urls_for_crawl:
                     urls_for_crawl.append(url)
 
@@ -605,7 +642,11 @@ def collect_agent_chunks(
         )
         context_samples.extend(contexts)
         for hit in hits:
-            if hit.url == "URL 없음" or hit.url in url_metadata:
+            if (
+                hit.url == "URL 없음"
+                or hit.url in url_metadata
+                or not _is_crawlable_url(hit.url)
+            ):
                 continue
             url_metadata[hit.url] = {
                 "query": hit.query,
@@ -615,6 +656,8 @@ def collect_agent_chunks(
         for url in new_urls:
             if len(urls_for_crawl) >= crawl_limit:
                 break
+            if not _is_crawlable_url(url):
+                continue
             if url not in urls_for_crawl:
                 urls_for_crawl.append(url)
 
@@ -647,7 +690,11 @@ def collect_agent_chunks(
                 seen_urls=seen_urls,
             )
             for hit in hits:
-                if hit.url == "URL 없음" or hit.url in url_metadata:
+                if (
+                    hit.url == "URL 없음"
+                    or hit.url in url_metadata
+                    or not _is_crawlable_url(hit.url)
+                ):
                     continue
                 url_metadata[hit.url] = {
                     "query": hit.query,
@@ -657,6 +704,8 @@ def collect_agent_chunks(
             for url in new_urls:
                 if len(urls_for_crawl) >= crawl_limit:
                     break
+                if not _is_crawlable_url(url):
+                    continue
                 if url not in urls_for_crawl:
                     urls_for_crawl.append(url)
 


### PR DESCRIPTION
## Summary
- add a crawl domain blocklist that skips YouTube-hosted URLs
- ensure Miner search and agent flows filter blocked domains before crawling
- document the YouTube crawling exclusion in the README

## Testing
- uv run python -m compileall miner

------
https://chatgpt.com/codex/tasks/task_e_68d3a87758ec832bbfe0796f469742a4