### PR TITLE
feat: implement crawler scheduler and worker orchestration

### DIFF
--- a/minor_search/__init__.py
+++ b/minor_search/__init__.py
@@ -1,5 +1,14 @@
 """Minor Search package."""
 
+from .crawler import (
+    CrawlJob,
+    CrawlState,
+    InMemoryJobQueue,
+    Master,
+    Scheduler,
+    Worker,
+    build_minio_storage_handler,
+)
 from .search import (
     AgentChunkResult,
     SearchChunk,
@@ -29,6 +38,13 @@ __all__ = [
     "SearchChunk",
     "SearchRunResult",
     "AgentChunkResult",
+    "CrawlJob",
+    "CrawlState",
+    "InMemoryJobQueue",
+    "Master",
+    "Scheduler",
+    "Worker",
+    "build_minio_storage_handler",
     "build_search_plan",
     "collect_agent_chunks",
     "run_search",

--- a/minor_search/crawler.py
+++ b/minor_search/crawler.py
@@ -1,0 +1,326 @@
+"""Queue-based crawling orchestration primitives.
+
+This module implements the Scheduler → Job Queue → Master → Worker pattern that the
+Minor Search documentation describes.  It provides in-memory defaults so the
+components can be exercised in unit tests or simple scripts without requiring an
+external Redis/SQS deployment, while still exposing extension points for
+production usage.
+
+The key pieces are:
+
+``CrawlJob``
+    Container describing a single unit of crawling work (query string plus
+    optional overrides and metadata).
+
+``InMemoryJobQueue``
+    Thread-safe FIFO queue used for tests and local experimentation.  The queue
+    implements the minimal operations required by the rest of the orchestrator
+    so that alternate backends (e.g. Redis) can be dropped in by providing a
+    compatible implementation.
+
+``Scheduler``
+    Responsible for seeding the queue with initial jobs.  It uses the shared
+    ``CrawlState`` to deduplicate queries so that the same task is not scheduled
+    repeatedly.
+
+``Worker``
+    Pops jobs from the queue, executes the search via the injected ``search``
+    callable, stores the resulting chunks when configured, and pushes any newly
+    discovered related queries back onto the queue.
+
+``Master``
+    Coordinates a pool of workers and drains the queue until no more work
+    remains or the optional job limit is reached.
+
+These utilities do not perform any network operations themselves; instead they
+delegate to the existing :func:`minor_search.search.run_search` helper (or any
+compatible callable).  This keeps the components easy to test and allows the
+production deployment to reuse the same crawling/search implementation already
+used by the CLI entry point.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import logging
+import threading
+import time
+from itertools import cycle
+from typing import Any, Callable, Deque, Iterable, Optional, Protocol
+
+from .search import AgentChunkResult, SearchRunResult
+
+logger = logging.getLogger(__name__)
+
+
+class JobQueue(Protocol):
+    """Minimal interface required for a job queue implementation."""
+
+    def enqueue(self, job: "CrawlJob") -> None:
+        """Add a job to the back of the queue."""
+
+    def requeue(self, job: "CrawlJob") -> None:
+        """Reinsert a job at the front of the queue (used for retries)."""
+
+    def dequeue(self, timeout: float | None = None) -> "CrawlJob | None":
+        """Pop a job from the front of the queue, waiting up to ``timeout`` seconds."""
+
+    def size(self) -> int:
+        """Return the number of jobs currently waiting in the queue."""
+
+
+@dataclass(slots=True)
+class CrawlJob:
+    """Description of a single crawling task pulled from the queue."""
+
+    query: str
+    store_result: bool = True
+    object_name: str | None = None
+    search_kwargs: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    attempts: int = 0
+
+    def normalized_query(self) -> str:
+        """Return a canonical representation used for deduplication."""
+
+        return " ".join(self.query.split())
+
+
+class CrawlState:
+    """Shared mutable state used to coordinate deduplication across workers."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._seen_queries: set[str] = set()
+
+    def mark_seen(self, query: str) -> bool:
+        """Return ``True`` if the query was not previously scheduled."""
+
+        normalized = " ".join(query.split())
+        if not normalized:
+            return False
+        with self._lock:
+            if normalized in self._seen_queries:
+                return False
+            self._seen_queries.add(normalized)
+            return True
+
+
+class InMemoryJobQueue(JobQueue):
+    """Simple FIFO job queue backed by :class:`collections.deque`."""
+
+    def __init__(self) -> None:
+        self._queue: Deque[CrawlJob] = deque()
+        self._condition = threading.Condition()
+
+    def enqueue(self, job: CrawlJob) -> None:
+        with self._condition:
+            self._queue.append(job)
+            self._condition.notify()
+
+    def requeue(self, job: CrawlJob) -> None:
+        with self._condition:
+            self._queue.appendleft(job)
+            self._condition.notify()
+
+    def dequeue(self, timeout: float | None = None) -> CrawlJob | None:
+        with self._condition:
+            if timeout is None:
+                while not self._queue:
+                    self._condition.wait()
+            else:
+                deadline = time.monotonic() + timeout
+                while not self._queue:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return None
+                    self._condition.wait(remaining)
+            return self._queue.popleft()
+
+    def size(self) -> int:
+        with self._condition:
+            return len(self._queue)
+
+
+class Scheduler:
+    """Seed the job queue with initial queries."""
+
+    def __init__(self, queue: JobQueue, state: CrawlState | None = None) -> None:
+        self.queue = queue
+        self.state = state or CrawlState()
+
+    def schedule(self, seeds: Iterable[str | CrawlJob]) -> int:
+        """Add the provided seeds to the queue, skipping duplicates."""
+
+        count = 0
+        for item in seeds:
+            job = item if isinstance(item, CrawlJob) else CrawlJob(query=str(item))
+            if not job.query.strip():
+                continue
+            if not self.state.mark_seen(job.query):
+                continue
+            self.queue.enqueue(job)
+            count += 1
+        return count
+
+
+StorageHandler = Callable[[CrawlJob, SearchRunResult], Optional[str]]
+ResultHandler = Callable[[CrawlJob, SearchRunResult, Optional[str]], None]
+
+
+def build_minio_storage_handler(client: Any, settings: Any) -> StorageHandler:
+    """Return a storage handler that uploads chunks to MinIO."""
+
+    from .storage.minio import store_agent_chunks  # Local import avoids cycle.
+
+    def _handler(job: CrawlJob, result: SearchRunResult) -> Optional[str]:
+        chunk_result = AgentChunkResult.from_run_result(result)
+        return store_agent_chunks(
+            client,
+            settings,
+            chunk_result,
+            object_name=job.object_name,
+        )
+
+    return _handler
+
+
+class Worker:
+    """Process crawl jobs pulled from the queue."""
+
+    def __init__(
+        self,
+        queue: JobQueue,
+        *,
+        state: CrawlState | None = None,
+        search: Callable[..., SearchRunResult],
+        default_search_kwargs: Optional[dict[str, Any]] = None,
+        storage_handler: StorageHandler | None = None,
+        result_handler: ResultHandler | None = None,
+        enqueue_related: bool = True,
+        max_retries: int = 2,
+        name: str | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.queue = queue
+        self.state = state or CrawlState()
+        self.search = search
+        self.default_search_kwargs = default_search_kwargs or {}
+        self.storage_handler = storage_handler
+        self.result_handler = result_handler
+        self.enqueue_related = enqueue_related
+        self.max_retries = max(0, max_retries)
+        self.name = name or "worker"
+        self.logger = logger or logging.getLogger(f"{__name__}.{self.name}")
+
+    def step(self, *, timeout: float | None = 1.0) -> bool:
+        """Attempt to process a single job from the queue."""
+
+        job = self.queue.dequeue(timeout=timeout)
+        if job is None:
+            return False
+        success = self._execute_job(job)
+        if not success and job.attempts < self.max_retries:
+            job.attempts += 1
+            self.queue.requeue(job)
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _execute_job(self, job: CrawlJob) -> bool:
+        try:
+            kwargs = dict(self.default_search_kwargs)
+            kwargs.update(job.search_kwargs)
+            result = self.search(job.query, **kwargs)
+        except Exception as exc:  # pragma: no cover - defensive logging branch.
+            self.logger.exception("%s failed: %s", job.normalized_query(), exc)
+            return False
+
+        object_name: Optional[str] = None
+        if self.storage_handler and job.store_result:
+            try:
+                object_name = self.storage_handler(job, result)
+            except Exception as exc:  # pragma: no cover - defensive logging.
+                self.logger.exception(
+                    "%s storage failed: %s", job.normalized_query(), exc
+                )
+                object_name = None
+
+        if self.result_handler:
+            self.result_handler(job, result, object_name)
+
+        if self.enqueue_related and result.related_queries:
+            for related in result.related_queries:
+                if not related or not related.strip():
+                    continue
+                if not self.state.mark_seen(related):
+                    continue
+                child_job = CrawlJob(
+                    query=related,
+                    store_result=job.store_result,
+                    object_name=None,
+                    search_kwargs=dict(job.search_kwargs),
+                    metadata={"parent_query": job.query},
+                )
+                self.queue.enqueue(child_job)
+
+        return True
+
+
+class Master:
+    """Coordinate a pool of workers to drain the job queue."""
+
+    def __init__(
+        self,
+        queue: JobQueue,
+        workers: Iterable[Worker],
+        *,
+        idle_sleep: float = 0.1,
+        max_idle_cycles: int = 10,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.queue = queue
+        self.workers = list(workers)
+        if not self.workers:
+            raise ValueError("At least one worker is required")
+        self.idle_sleep = idle_sleep
+        self.max_idle_cycles = max(1, max_idle_cycles)
+        self.logger = logger or logging.getLogger(f"{__name__}.master")
+
+    def run(self, *, max_jobs: int | None = None) -> int:
+        """Drain the queue using the managed workers."""
+
+        processed = 0
+        idle_cycles = 0
+        worker_cycle = cycle(self.workers)
+
+        while max_jobs is None or processed < max_jobs:
+            worker = next(worker_cycle)
+            if worker.step(timeout=self.idle_sleep):
+                processed += 1
+                idle_cycles = 0
+                continue
+
+            idle_cycles += 1
+            if idle_cycles >= self.max_idle_cycles * len(self.workers):
+                if self.queue.size() == 0:
+                    break
+                idle_cycles = 0
+
+        self.logger.debug("Master run complete – processed jobs: %d", processed)
+        return processed
+
+
+__all__ = [
+    "CrawlJob",
+    "CrawlState",
+    "InMemoryJobQueue",
+    "JobQueue",
+    "Master",
+    "Scheduler",
+    "Worker",
+    "build_minio_storage_handler",
+]
+

--- a/minor_search/tests/test_crawler.py
+++ b/minor_search/tests/test_crawler.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from uuid import uuid4
+
+PACKAGE_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = PACKAGE_DIR.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+stub_package = ModuleType("minor_search")
+stub_package.__path__ = [str(PACKAGE_DIR)]
+sys.modules.setdefault("minor_search", stub_package)
+
+minor_stub = ModuleType("minor")
+minor_stub.__path__ = []
+sys.modules.setdefault("minor", minor_stub)
+
+logbook_stub = ModuleType("minor.logbook")
+logbook_stub.log_search_run = lambda **_: uuid4()
+sys.modules.setdefault("minor.logbook", logbook_stub)
+minor_stub.logbook = logbook_stub
+
+langchain_core_tools = ModuleType("langchain_core.tools")
+
+
+def _tool(func: Callable | None = None, **_: object):
+    if func is None:
+        def decorator(inner: Callable) -> Callable:
+            return inner
+        return decorator
+    return func
+
+
+langchain_core_tools.tool = _tool
+langchain_core_module = ModuleType("langchain_core")
+langchain_core_module.tools = langchain_core_tools
+sys.modules.setdefault("langchain_core", langchain_core_module)
+sys.modules.setdefault("langchain_core.tools", langchain_core_tools)
+
+crawler_module = importlib.import_module("minor_search.crawler")
+search_module = importlib.import_module("minor_search.search")
+
+CrawlJob = crawler_module.CrawlJob
+CrawlState = crawler_module.CrawlState
+InMemoryJobQueue = crawler_module.InMemoryJobQueue
+Master = crawler_module.Master
+Scheduler = crawler_module.Scheduler
+Worker = crawler_module.Worker
+SearchChunk = search_module.SearchChunk
+SearchRunResult = search_module.SearchRunResult
+
+
+@dataclass
+class FakeResult:
+    """Utility container to configure fake search responses."""
+
+    related_queries: list[str]
+
+    def to_run_result(self) -> SearchRunResult:
+        chunk = SearchChunk(
+            query="seed",
+            source_label="TEST",
+            url="https://example.com",
+            title="Example",
+            chunk_index=1,
+            content="Example content",
+        )
+        return SearchRunResult(
+            base_query="seed",
+            sections=["section"],
+            markdown="md",
+            related_queries=self.related_queries,
+            chunks=[chunk],
+            failures=[],
+        )
+
+
+def test_scheduler_enqueues_unique_jobs() -> None:
+    queue = InMemoryJobQueue()
+    state = CrawlState()
+    scheduler = Scheduler(queue, state)
+
+    seeds = [" 질의 ", CrawlJob(query="질의"), "다른 질의"]
+    count = scheduler.schedule(seeds)
+
+    assert count == 2
+    assert queue.size() == 2
+    first = queue.dequeue()
+    second = queue.dequeue()
+    assert first is not None and first.query.strip() == "질의"
+    assert second is not None and second.query == "다른 질의"
+
+
+def test_worker_processes_job_and_enqueues_related() -> None:
+    queue = InMemoryJobQueue()
+    state = CrawlState()
+    scheduler = Scheduler(queue, state)
+
+    handled = []
+
+    def fake_search(query: str, **_: object) -> SearchRunResult:
+        if query == "seed":
+            return FakeResult(["follow up", "seed"]).to_run_result()
+        return FakeResult([]).to_run_result()
+
+    def result_handler(job: CrawlJob, result: SearchRunResult, object_name: str | None) -> None:
+        handled.append((job.query, len(result.chunks), object_name))
+
+    scheduler.schedule(["seed"])
+    worker = Worker(
+        queue,
+        state=state,
+        search=fake_search,
+        default_search_kwargs={"crawl_limit": 1},
+        result_handler=result_handler,
+    )
+
+    assert worker.step(timeout=0.01)
+    assert handled and handled[0][0] == "seed"
+
+    # ``seed`` should not be enqueued again because of deduplication, but the
+    # new "follow up" query should appear.
+    next_job = queue.dequeue(timeout=0.01)
+    assert next_job is not None
+    assert next_job.query == "follow up"
+
+
+def test_master_drains_queue_with_multiple_workers() -> None:
+    queue = InMemoryJobQueue()
+    state = CrawlState()
+    scheduler = Scheduler(queue, state)
+
+    results = {
+        "seed-1": FakeResult(["seed-3"]).to_run_result(),
+        "seed-2": FakeResult([]).to_run_result(),
+        "seed-3": FakeResult([]).to_run_result(),
+    }
+
+    def fake_search(query: str, **_: object) -> SearchRunResult:
+        return results[query]
+
+    scheduler.schedule(["seed-1", "seed-2"])
+
+    workers = [
+        Worker(queue, state=state, search=fake_search, name="w1"),
+        Worker(queue, state=state, search=fake_search, name="w2"),
+    ]
+
+    master = Master(queue, workers, idle_sleep=0.01, max_idle_cycles=5)
+    processed = master.run()
+
+    # Three jobs should be processed (seed-1, seed-2, seed-3).
+    assert processed == 3
+    assert queue.size() == 0
+


### PR DESCRIPTION
## Summary
- add a crawler orchestration module with scheduler, queue, worker, and master primitives
- expose the new orchestration helpers via the package __init__
- cover the new components with unit tests validating scheduling, worker behaviour, and master coordination

## Testing
- pytest minor_search/tests

------
https://chatgpt.com/codex/tasks/task_e_68d3bfc4212c832b83f54af2e4cde88e